### PR TITLE
Ensure "Token" covers all relevant projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 &ensp; &ensp; &ensp; &ensp; (ii)  that is capable of being transferred between persons without an intermediary party; and
 
-&ensp; &ensp; &ensp; &ensp; (iii)  that does not represent a financial interest in a company, partnership, or fund, including an ownership or debt interest, revenue share, entitlement to any interest or dividend payment.
+&ensp; &ensp; &ensp; &ensp; (iii)  that does not represent a financial interest in a centralized company, partnership, or fund, including an ownership or debt interest, revenue share, entitlement to any interest or dividend payment.
 
 Proposed Exchange Act Rule 3a1-2.  Exemption from the definition of “exchange” under Section 3(a)(1) of the Act.
 


### PR DESCRIPTION
To allow DeFi projects to function under this safe harbour, it's necessary to redefine the restriction on Token financial interests. Specifically, we need to be sure that a DAO-type organization can function, where decentralized users pool effort and/or capital. Limiting the restriction to centralized companies, partnerships, and funds is the cleanest change that would allow this. The restriction would still prevent a token being ownership of a hedge fund, but would now allow use cases such as Ethereum's Proof of Stake.