### PR TITLE
Add to the disclosure requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 &ensp; &ensp; (5)  An exit report is filed in accordance with paragraph (f) of this section.  
 
-**(b)  Disclosure.**  The Initial Development Team must provide the information described below on a freely accessible public website.  
+**(b)  Disclosure.**  The Initial Development Team must provide the information described below on a freely accessible public website, and must link to this information from any websites, software, and services related to the network and controlled by The Initial Development Team.  
 
 &ensp; &ensp; (1)  *Initial Disclosures.*  Prior to filing a notice of reliance on the safe harbor, provide the following information.  Any material changes to the information required below must be provided on the same freely accessible public website as soon as practicable after the change.
 


### PR DESCRIPTION
It's necessary, but not sufficient, to post disclosures on a public website; the disclosures must be readily available to the public in the venues where the Initial Development team is talking about the network. Otherwise, I could post disclosures on www.thisisadisclosurethatyouwillnevereverfind.com, and be compliant with the rule, but ineffective at communicating the disclosure to the public.