### PR TITLE
Improve Initial Dev Team definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 **(k)  Definitions.**
 
-&ensp; &ensp; (1)  *Initial Development Team.*  Any person, group of persons, or entity that provides the essential managerial efforts for the development of the network prior to reaching Network Maturity and makes the initial filing of a notice of reliance on this safe harbor.
+&ensp; &ensp; (1)  *Initial Development Team.*  Any person, group of persons, or entity that provides the essential managerial efforts for the development of the network prior to reaching Network Maturity. The Initial Development team is responsible for the initial filing of a notice of reliance on this safe harbor, and for maintaining the public Disclosure.
 
 &ensp; &ensp; (2)  *Network Maturity.*  Network Maturity is the status of a decentralized or functional network that is achieved when the network is either:
 


### PR DESCRIPTION
The previous definition required the Initial Development Team to be the person(s) who filed the notice of reliance. There are cases where a dev team can completely change composition during a project (one company buying another company; the death of a key member; rotation of team members through good decentralized governance practices), so the Initial Development Team should be defined more narrowly.

In addition, that team should be clearly identified as being responsible for maintaining the Disclosure.