### PR TITLE
Add identifying information to the exit report

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 &ensp; &ensp; &ensp; &ensp; &ensp; &ensp; (B)  Contact information for Token holders to communicate with the Initial Development Team.  
 
-&ensp; &ensp; &ensp; &ensp; &ensp; &ensp; (C)  A statement acknowledging that the Initial Development team will file a Form 10 to register under Section 12(g) of the Securities Exchange Act of 1934 the Tokens as a class of securities within 120 days of the filing of the exit report.      
+&ensp; &ensp; &ensp; &ensp; &ensp; &ensp; (C)  A statement acknowledging that the Initial Development team will file a Form 10 to register under Section 12(g) of the Securities Exchange Act of 1934 the Tokens as a class of securities within 120 days of the filing of the exit report.     
+
+&ensp; &ensp; &ensp; &ensp; (iv)  The url of the website where disclosure required under paragraph (b) may be accessed.
 
 &ensp; &ensp; (2)  The exit report must be filed with the Commission in electronic format through EDGAR in accordance with EDGAR rules set forth in Regulation S-T.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 **(e)  Duration of Exemption.**  The relief provided by this section will expire three years from the date the notice of reliance was filed.  
 
-**(f)  Exit Report.**  An exit report must be filed no later than the date of expiration as calculated in paragraph (e) of this section.  
+**(f)  Exit Report.**  The Initial Development Team must file an exit report no later than the date of expiration as calculated in paragraph (e) of this section.  
 
 &ensp; &ensp; (1) The exit report must contain the following information:
 
@@ -126,6 +126,8 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 &ensp; &ensp; &ensp; &ensp; &ensp; &ensp; (C)  A statement acknowledging that the Initial Development team will file a Form 10 to register under Section 12(g) of the Securities Exchange Act of 1934 the Tokens as a class of securities within 120 days of the filing of the exit report.     
 
 &ensp; &ensp; &ensp; &ensp; (iv)  The url of the website where disclosure required under paragraph (b) may be accessed.
+
+&ensp; &ensp; &ensp; &ensp; (v)  Attestation by a person duly authorized by the Initial Development Team that the conditions of this section are satisfied
 
 &ensp; &ensp; (2)  The exit report must be filed with the Commission in electronic format through EDGAR in accordance with EDGAR rules set forth in Regulation S-T.
 


### PR DESCRIPTION
(a) Until the exit report is filed, the Token is operating under safe harbour. While the token is operating under safe harbour, there is an Initial Development Team, and that team has legal accountability for the Token and any warranties made to the SEC or other entities. Therefore, the Initial Development Team must file the exit report

(b) The exit report had no clear way of linking the exit report back to the notice of reliance or the disclosure. Adding the public website url will at least make it possible to track an exit report back to the initial project (especially for exit reports filed by persons other than the Initial Development Team), and ensures the current information is available to reviewers, even if the url has changed.