### PR TITLE
Expectation of Token and Network Maturity

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 **(a)  Exemption.**  Except as expressly provided in paragraph (d) of this section, the Securities Act of 1933 does not apply to any offer, sale, or transaction involving a Token if the following conditions are satisfied by the Initial Development Team, as defined herein.
 
-&ensp; &ensp; (1)  The Initial Development Team intends for the network on which the Token functions to reach Network Maturity within three years of the date of the first sale of Tokens;
+&ensp; &ensp; (1)  The Initial Development Team intends for the Token and the network or networks on which the Token functions to reach Network Maturity within three years of the date of the first sale of Tokens;
 
 &ensp; &ensp; (2)  Disclosures required under paragraph (b) of this section must be made available on a freely accessible public website.
 


### PR DESCRIPTION
For some Tokens, the network on which the Token functions is already at Network Maturity (an ERC-20 token on Ethereum). We need to ensure that there's no loophole here. Requiring both the Token and the network on which it functions to have reached Network Maturity prevents that loophole. Also, some Tokens function on multiple networks, so adding "or networks" here.

Note: This clause does prevent Tokens on centralized blockchains from taking this step, so it would not allow Token safe harbor on a chain such as Binance Chain, where it is not decentralized. I think this is a good thing, as it also ensures that any underlying blockchain is sufficiently decentralized, reducing the risk of a bad actor creating a decentralized project on a larger centralized network.