### PR TITLE
Lining up safe harbour durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 **(a)  Exemption.**  Except as expressly provided in paragraph (d) of this section, the Securities Act of 1933 does not apply to any offer, sale, or transaction involving a Token if the following conditions are satisfied by the Initial Development Team, as defined herein.
 
-&ensp; &ensp; (1)  The Initial Development Team intends for the network on which the Token functions to reach Network Maturity within three years of the date of the first sale of Tokens;
+&ensp; &ensp; (1)  The Initial Development Team intends for the network on which the Token functions to reach Network Maturity within three years of the date of the first sale of Tokens, or three years from the effective date of this rule, whichever is later;
 
 &ensp; &ensp; (2)  Disclosures required under paragraph (b) of this section must be made available on a freely accessible public website.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,11 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 **(d)  Limitation.**  The exemption provided in paragraph (a) of this section does not apply to the provisions of Section 12(a)(2) or Section 17 of the Securities Act of 1933.
 
-**(e)  Duration of Exemption.**  The relief provided by this section will expire three years from the date the notice of reliance was filed.  
+**(e)  Duration of Exemption.**  The relief provided by this section will expire the later of:
+
+&ensp; &ensp; (1)  Three years from the date of the first sale of Tokens; or
+
+&ensp; &ensp; (2)  Three years from the effective date of this rule.  
 
 **(f)  Exit Report.**  An exit report must be filed no later than the date of expiration as calculated in paragraph (e) of this section.  
 


### PR DESCRIPTION
The durations of the rule were contradictory, between (a)(1) - 3 years from the first token sale, and (e) - 3 years from filing the notice of reliance. Also, Section (h) allows filing as soon as practicable, meaning a prior Token, which has already had more time to reach Network Maturity, could gain extra time to reach Network Maturity that a new Token could not.

To that effect, make the duration the later of (a) three years after the date of first sale of tokens, or (b) three years after the rule is effective. The second ensures a level playing field for projects that previously sold tokens; their clock starts on a clearly-defined day. Apologies to the SEC employees who, three years after that date, have to sift through a couple of thousand exit reports.