### PR TITLE
Clarifies the scope of Related Person Transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 &ensp; &ensp; &ensp; &ensp; The definition is not meant to preclude network alterations achieved through a predetermined procedure in the source code that uses a consensus mechanism and approval of network participants.
 
-&ensp; &ensp; (3)  *Related Person.*  Related person means the members of the Initial Development Team, directors or advisors to the Initial Development Team, and any immediate family member of such persons. 
+&ensp; &ensp; (3)  *Related Person.*  Related person means any individual member of the Initial Development Team, any director or advisor to the Initial Development Team, and any immediate family member of such persons. 
 
 &ensp; &ensp; (4)  *Token.*  A Token is a digital representation of value or rights
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 &ensp; &ensp; &ensp; &ensp; (viii)  *Sales of Tokens by Initial Development Team.*  Each time a member of the Initial Development Team sells five percent of his or her Tokens as disclosed pursuant to paragraph (b)(1)(vi)(B) of this section over any period of time, state the date(s) of the sale, the number of Tokens sold, and the identity of the seller.   
 
-&ensp; &ensp; &ensp; &ensp; (ix)  *Related Person Transactions.*  A description of any material transaction, or any proposed material transaction, in which the Initial Development Team is a participant and in which any Related Person had or will have a direct or indirect material interest.  The description should identify the nature of the transaction, the Related Person, the basis on which the person is a Related Person, and the approximate value of the amount involved in the transaction.  
+&ensp; &ensp; &ensp; &ensp; (ix)  *Related Person Transactions.*  A description of any material transaction, or any proposed material transaction, in which one or more Related Persons participate and had or will have a direct or indirect material interest.  The description should identify the nature of the transaction, the Related Person, the basis on which the person is a Related Person, and the approximate value of the amount involved in the transaction.  
 
 &ensp; &ensp; &ensp; &ensp; (x)  *Warning to Token Purchasers.*  A statement that the purchase of Tokens involves a high degree of risk and the potential loss of money.  
 
@@ -147,7 +147,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 &ensp; &ensp; &ensp; &ensp; The definition is not meant to preclude network alterations achieved through a predetermined procedure in the source code that uses a consensus mechanism and approval of network participants.
 
-&ensp; &ensp; (3)  *Related Person.*  Related person means the Initial Development Team, directors or advisors to the Initial Development Team, and any immediately family member of such persons.  
+&ensp; &ensp; (3)  *Related Person.*  Related person means the members of the Initial Development Team, directors or advisors to the Initial Development Team, and any immediately family member of such persons. 
 
 &ensp; &ensp; (4)  *Token.*  A Token is a digital representation of value or rights
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 &ensp; &ensp; &ensp; &ensp; The definition is not meant to preclude network alterations achieved through a predetermined procedure in the source code that uses a consensus mechanism and approval of network participants.
 
-&ensp; &ensp; (3)  *Related Person.*  Related person means the members of the Initial Development Team, directors or advisors to the Initial Development Team, and any immediately family member of such persons. 
+&ensp; &ensp; (3)  *Related Person.*  Related person means the members of the Initial Development Team, directors or advisors to the Initial Development Team, and any immediate family member of such persons. 
 
 &ensp; &ensp; (4)  *Token.*  A Token is a digital representation of value or rights
 


### PR DESCRIPTION
The language below raises a few questions:

```
#§(b)(1)(vi)

...any material transaction, or any proposed material transaction, in which the 
Initial Development Team is a participant and in which any Related Person had 
or will have a direct or indirect material interest.

```

1. What if some members of the IDT are participating in the transaction, but others are not?
2. What if a member of the IDT is the only Related Person participating, but doesn't have a material interest in the transaction?
3. What if a non-IDT Related Person is the only participant in the transaction?

This PR proposes the following revisions to clarify:

```
#§(b)(1)(vi)

...any material transaction, or any proposed material transaction, in which one 
or more Related Persons participate and had or will have a direct or indirect 
material interest.


#§(k)(3)

Related person means any individual member of the Initial Development Team, any 
director or advisor to the Initial Development Team, and any immediate family 
member of such persons.

```

...which would answer the questions above as follows:

1. If even one member of the IDT is participating, the transaction should be in-scope for the disclosure requirement.
2. In order to trigger the disclosure requirement, both participation by at least one Related Person _AND_ a material interest in the transaction are required.
3. If a Related Person who isn't on the IDT is the only participant—_e.g._, an advisor or an immediate family member—the transaction should be in-scope for the disclosure requirement.