### PR TITLE
Clarify that excluded financial interests are bound to "company, partnership, or fund"

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Potential Proposed Securities Act Rule 195. Time-limited exemption for Tokens.
 
 &ensp; &ensp; &ensp; &ensp; (ii)  that is capable of being transferred between persons without an intermediary party; and
 
-&ensp; &ensp; &ensp; &ensp; (iii)  that does not represent a financial interest in a company, partnership, or fund, including an ownership or debt interest, revenue share, entitlement to any interest or dividend payment.
+&ensp; &ensp; &ensp; &ensp; (iii)  that does not represent a financial interest (e.g., an ownership or debt interest, a revenue share, an entitlement to any interest, or a dividend payment) in a company, partnership, or fund.
 
 Proposed Exchange Act Rule 3a1-2.  Exemption from the definition of “exchange” under Section 3(a)(1) of the Act.
 


### PR DESCRIPTION
This PR attempts to clarify that the examples of financial interests are not meant to exclude any of the enumerated examples from the definition of Token, except as they relate to a "company, partnership, or fund".

Although I happen to agree with the issues raised in #4  and #12, I've left "fund" in this PR for now. 